### PR TITLE
Fix docker-compose command

### DIFF
--- a/src/guide/build-and-install.md
+++ b/src/guide/build-and-install.md
@@ -252,7 +252,7 @@ for reproducible management of configurations, which is oftentimes tricky
 on bare metal.
 
 ```bash
-docker compose up
+docker-compose up
 ```
 
 ::: info

--- a/src/guide/python.md
+++ b/src/guide/python.md
@@ -55,7 +55,7 @@ cp -vfr ~/Git/iroha/configs/client_cli/config.json example/config.json
 ::: tip
 
 You can also use the provided `config.json` in the `example` folder if you
-also call `docker compose up` from that same folder. This has to do with
+also call `docker-compose up` from that same folder. This has to do with
 the fact that the configuration for the Docker files in Iroha Python is
 slightly different.
 


### PR DESCRIPTION
While working on https://github.com/hyperledger/iroha/issues/1466, I've noted a "docker compose command". I don't think [Compose](https://docs.docker.com/compose/) is a part of default Docker distribution.

If I will try to run it with just `docker` command, I'll see this:

```bash
$ docker compose up
docker: 'compose' is not a docker command.
See 'docker --help'
```

Versions:

```
Docker version 20.10.16, build aa7e414fdc
docker-compose version 1.29.2, build 5becea4c
```

Signed-off-by: 6r1d <vic.6r1d@gmail.com>