### PR TITLE
[ci]: run `build` in PR CI as well

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Check documentation formatting
         run: pnpm format:docs:check
+
+      - name: Build documentation
+        run: pnpm build

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -1,4 +1,4 @@
-name: Format Docs
+name: Pull Request CI
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Now we will be able to inspect build errors in GitHub instead of Vercel.

Signed-off-by: 0x009922 <a.marcius26@gmail.com>