### PR TITLE
[docs] Add a missing cd command

### DIFF
--- a/src/guide/python.md
+++ b/src/guide/python.md
@@ -23,6 +23,7 @@ repository into it:
 ```bash
 cd ~/Git/
 git clone https://github.com/hyperledger/iroha-python/ --branch iroha2
+cd iroha-python
 ```
 
 Iroha Python is written in Rust using the PyO3 library. Thus, unlike most


### PR DESCRIPTION
Previously, a `cd` command was missing and a change was requested by @learningnoobi.

Signed-off-by: 6r1d <vic.6r1d@gmail.com>