### PR TITLE
[docs] Update links #239

### DIFF
--- a/src/guide/configure/genesis.md
+++ b/src/guide/configure/genesis.md
@@ -69,7 +69,7 @@ You can use `kagami` to generate the default genesis block:
   specified file:
 
   ```bash
-  kagami genesis >genesis.json
+  kagami genesis > genesis.json
   ```
 
 - Generate a synthetic genesis block in JSON format and write the `n`

--- a/src/guide/iroha-2.md
+++ b/src/guide/iroha-2.md
@@ -26,7 +26,7 @@ would be accessible from Iroha 2.
 
 Iroha 2 learned a great deal from the development of the original Iroha. Of
 particular importance is the new and improved Byzantine-fault-tolerant
-consensus algorithm: _Sumeragi_. This new consensus allowed us to expand
+consensus algorithm: [_Sumeragi_](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/iroha_2_whitepaper.md#28-consensus). This new consensus allowed us to expand
 what could be done on a blockchain without any security risks.
 
 ::: info

--- a/src/index.md
+++ b/src/index.md
@@ -7,33 +7,33 @@ Iroha is a fully-featured blockchain ledger. With Iroha you can:
 - Create and manage non-fungible assets
 - Manage user accounts with a domain hierarchy and multi-signature
   transactions
-- Use efficient portable smart contracts implemented either via WebAssembly
-  or Iroha Special Instructions
+- Use efficient portable smart contracts implemented either via [WebAssembly](guide/blockchain/wasm.md)
+  or [Iroha Special Instructions](guide/blockchain/instructions.md)
 - Use both permissioned and permission-less blockchain deployments
 
 ## How Iroha works
 
 To understand how Iroha operates, let's draw parallels between a blockchain
 and a computer. If the blockchain is the computer, then in this metaphor of
-ours the client binary (for example: `iroha_client_cli`) is the keyboard,
+ours the client binary (for example: [`iroha_client_cli`](guide/bash.md)) is the keyboard,
 the blockchain is the hard drive, and the Iroha peer software is the
 processor. Like a processor, Iroha accepts portable instructions that
 modify what's written to the blockchain, allow certain users to use the
 network, and lock others out.
 
 Any operation that is run on-chain is written in terms of
-[Iroha Special Instructions (ISI)](./guide/blockchain/instructions.md), and
+[Iroha Special Instructions (ISI)](guide/blockchain/instructions.md), and
 there is no other way of modifying the world state.
 
 Each interaction with the blockchain is done via a _transaction_. A
 transaction is a collection of _instructions_, which are either glued
 together in sequence or compiled into what we affectionately call a
-[WASM](./guide/blockchain/wasm.md) blob. You need these instructions to
+[WASM](guide/blockchain/wasm.md) blob. You need these instructions to
 register an account, remove an account, add X amount of Y currency, and so
 on.
 
 To read the information encoded in the blocks of a blockchain (the current
-world state), you use [queries](./guide/blockchain/queries.md). Queries are
+world state), you use [queries](guide/blockchain/queries.md). Queries are
 submitted like instructions, but they're not tracked and recorded in
 blocks, so they're much more lightweight. If you use queries as part of
 complicated logic (e.g. inside WASM), they have a non-negligible impact on
@@ -43,24 +43,24 @@ no trace in the blockchain.
 ## Navigation
 
 If you have previously worked with Iroha, start with our comparison of
-[Iroha 1 and Iroha 2](./guide/iroha-2.md). That will help you understand
+[Iroha 1 and Iroha 2](guide/iroha-2.md). That will help you understand
 the differences between the two versions and upgrade to the newer one.
 
 Check the [tutorial](guide/intro.md) part of this documentation where you
-can follow one of the available language-specific guides in Bash, Rust,
-Kotlin, Javascript, or Python. The guides introduce you to the basic
+can follow one of the available language-specific guides in [Bash](guide/bash.md), [Rust](guide/rust.md),
+[Kotlin](guide/kotlin-java.md), [Javascript](guide/javascript.md), or [Python](guide/python.md). The guides introduce you to the basic
 concepts and provide code snippets that you can run yourself.
 
 In the Blockchain chapter you can find documentation for Iroha features,
-such as [Iroha Special Instructions](/guide/blockchain/instructions.md),
-[triggers](/guide/blockchain/triggers.md),
-[queries](/guide/blockchain/queries.md).
+such as [Iroha Special Instructions](guide/blockchain/instructions.md),
+[triggers](guide/blockchain/triggers.md),
+[queries](guide/blockchain/queries.md).
 
 The Configuration and Management section explains Iroha 2 configuration
 files in greater detail and covers topics such as
-[public key cryptography](/guide/configure/keys.md),
-[peer management](/guide/configure/peer-management.md), and
-[public and private modes](/guide/configure/modes.md).
+[public key cryptography](guide/configure/keys.md),
+[peer management](guide/configure/peer-management.md), and
+[public and private modes](guide/configure/modes.md).
 
 ## Learn More
 


### PR DESCRIPTION
I would like to add some new links, because it may be convenient for the new users.

* `iroha_client_cli` - link to "how Iroha works"
* "Use efficient portable smart contracts implemented either via WebAssembly" - link to WASM
* "Bash, Rust, Kotlin, Javascript, or Python" - language guides
* "Iroha 2 vs. Iroha 1" → "Fault Tolerance" - link to the Sumeragi whitepaper

This PR also contains some cosmetic changes: uniform links in the index file and a whitespace change in a command.