### PR TITLE
[docs] Extend the glossary

### DIFF
--- a/src/guide/glossary.md
+++ b/src/guide/glossary.md
@@ -25,10 +25,44 @@ Here you can find definitions of all Iroha-related entities.
 - [World state view (WSV)](#world-state-view-wsv)
 - [Leader](#leader)
 
+## Blockchain ledgers
+
+Blockchain ledgers are digital record-keeping systems that use blockchain technology to keep financial records.
+These are named after old-fashioned books used for financial records[^1] because of their history.
+
+During medieval times, ledger books were open for public viewing and accuracy verification.
+This idea found its reflection in the blockchain-based systems that can check the stored data for validity.
+
 ## Asset
 
-A representation of a valuable object on the blockchain. More on assets
-[here](/guide/blockchain/assets.md).
+While the word itself means a valuable object, with blockchain being involved, we'll be talking about a representation of a valuable object on the blockchain.
+
+Additional information on assets is available [here](/guide/blockchain/assets.md).
+
+### Fungible assets
+
+Such assets can be easily swapped with other assets of the same type, because they are interchangeable.
+
+As an example, all units of the same currency are equal in their value and can be used to purchase goods.
+Normally, the fungible assets are typically identical in appearance, besides the wear for banknotes and coins.
+
+### Non-fungible assets
+
+Non-fungible assets are unique and valuable due to their specific characteristics and rarity; their value cannot be compared to other assets.
+
+* A painting's value can vary based on the artist, the time it was painted, and the public's interest in it.
+* Two houses on the same street may have differing levels of maintenance.
+* Jewellery manufacturers typically offer a range of different designs.
+
+### Mintable assets
+
+An asset is mintable if it's allowed to issue more of the same type.
+
+### Non-mintable assets
+
+If the initial amount of an asset is specified once and doesn't change, it is considered non-mintable.
+
+The [Genesis block](/guide/configure/genesis.md) sets this information for Iroha configuration.
 
 ## Byzantine fault-tolerance (BFT)
 
@@ -154,3 +188,5 @@ privilege of forming the next block. This privilege can be revoked in
 networks that achieve
 [Byzantine fault-torelance](#byzantine-fault-tolerance-bft) via
 [view change](#view-change).
+
+[^1]: for example, prices, news, and transaction information

--- a/src/guide/glossary.md
+++ b/src/guide/glossary.md
@@ -35,7 +35,7 @@ This idea is reflected in the blockchain-based systems that can check the stored
 
 ## Asset
 
-While the word itself means a valuable object, with blockchain being involved, we'll be talking about a representation of a valuable object on the blockchain.
+In the context of blockchains, an asset is the representation of a valuable object on the blockchain.
 
 Additional information on assets is available [here](/guide/blockchain/assets.md).
 

--- a/src/guide/glossary.md
+++ b/src/guide/glossary.md
@@ -28,10 +28,10 @@ Here you can find definitions of all Iroha-related entities.
 ## Blockchain ledgers
 
 Blockchain ledgers are digital record-keeping systems that use blockchain technology to keep financial records.
-These are named after old-fashioned books used for financial records[^1] because of their history.
+These are named after old-fashioned books that were used for financial records such as prices, news, and transaction information.
 
 During medieval times, ledger books were open for public viewing and accuracy verification.
-This idea found its reflection in the blockchain-based systems that can check the stored data for validity.
+This idea is reflected in the blockchain-based systems that can check the stored data for validity.
 
 ## Asset
 
@@ -41,28 +41,28 @@ Additional information on assets is available [here](/guide/blockchain/assets.md
 
 ### Fungible assets
 
-Such assets can be easily swapped with other assets of the same type, because they are interchangeable.
+Such assets can be easily swapped for other assets of the same type because they are interchangeable.
 
 As an example, all units of the same currency are equal in their value and can be used to purchase goods.
-Normally, the fungible assets are typically identical in appearance, besides the wear for banknotes and coins.
+Typically, fungible assets are identical in appearance, aside from the wear of banknotes and coins.
 
 ### Non-fungible assets
 
 Non-fungible assets are unique and valuable due to their specific characteristics and rarity; their value cannot be compared to other assets.
 
-* A painting's value can vary based on the artist, the time it was painted, and the public's interest in it.
+* A painting's value can vary based on the artist, the time period it was painted, and the public's interest in it.
 * Two houses on the same street may have differing levels of maintenance.
 * Jewellery manufacturers typically offer a range of different designs.
 
 ### Mintable assets
 
-An asset is mintable if it's allowed to issue more of the same type.
+An asset is mintable if more of the same type can be issued.
 
 ### Non-mintable assets
 
 If the initial amount of an asset is specified once and doesn't change, it is considered non-mintable.
 
-The [Genesis block](/guide/configure/genesis.md) sets this information for Iroha configuration.
+The [Genesis block](/guide/configure/genesis.md) sets this information for the Iroha configuration.
 
 ## Byzantine fault-tolerance (BFT)
 
@@ -188,5 +188,3 @@ privilege of forming the next block. This privilege can be revoked in
 networks that achieve
 [Byzantine fault-torelance](#byzantine-fault-tolerance-bft) via
 [view change](#view-change).
-
-[^1]: for example, prices, news, and transaction information

--- a/src/index.md
+++ b/src/index.md
@@ -1,10 +1,10 @@
 # Iroha 2 Documentation
 
-Iroha is a fully-featured blockchain ledger. With Iroha you can:
+Iroha is a fully-featured [blockchain ledger](guide/glossary.md#blockchain-ledgers). With Iroha you can:
 
-- Create and manage custom fungible assets, such as currencies, gold, and
+- Create and manage custom [fungible assets](guide/glossary.md#fungible-assets), such as currencies, gold, and
   others
-- Create and manage non-fungible assets
+- Create and manage [non-fungible](guide/glossary.md#non-fungible-assets) assets
 - Manage user accounts with a domain hierarchy and multi-signature
   transactions
 - Use efficient portable smart contracts implemented either via [WebAssembly](guide/blockchain/wasm.md)


### PR DESCRIPTION
A small extension for the glossary, so the doc is easier to navigate without confusing the user with the terminology.
It is possible to link the assets instead of the glossary for the asset-related part, but I believe the glossary section should be separate.

Signed-off-by: 6r1d <vic.6r1d@gmail.com>