### PR TITLE
[docs] #249: Add the support channels

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -36,6 +36,10 @@ function getGuideSidebar(): DefaultTheme.SidebarGroup[] {
           link: '/guide/build-and-install',
         },
         {
+            text: 'Receive support',
+            link: '/guide/support.md',
+        },
+        {
           text: 'Glossary',
           link: '/guide/glossary.md',
         },

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -36,8 +36,8 @@ function getGuideSidebar(): DefaultTheme.SidebarGroup[] {
           link: '/guide/build-and-install',
         },
         {
-            text: 'Receive support',
-            link: '/guide/support.md',
+          text: 'Receive support',
+          link: '/guide/support.md',
         },
         {
           text: 'Glossary',

--- a/src/guide/support.md
+++ b/src/guide/support.md
@@ -5,6 +5,6 @@ There are three ways to quickly get in touch with our community: Telegram, Disco
 
 A large part of the community currently uses [Telegram](https://t.me/hyperledgeriroha) for communication.
 The Hyperledger part of the team prefers [Discord](https://discord.gg/hyperledger), with two dedicated channels: `iroha` and `iroha-2-contributors`.
-The Discord and Telegram channels are synchronised, and users of both channels see your messages.
+The Discord and Telegram channels are synchronized, so users of both media see your messages.
 
 Finally, you can [create](https://github.com/hyperledger/iroha/issues/new/choose) a GitHub issue, whether it's a request to update documentation, a suggestion for the core team, or a bug you have found.

--- a/src/guide/support.md
+++ b/src/guide/support.md
@@ -1,0 +1,10 @@
+# Receive support
+
+From time to time, you may have questions about Iroha that you would like to discuss in detail with others.
+There are three ways to quickly get in touch with our community: Telegram, Discord and GitHub.
+
+A large part of the community currently uses [Telegram](https://t.me/hyperledgeriroha) for communication.
+The Hyperledger part of the team prefers [Discord](https://discord.gg/hyperledger), with two dedicated channels: `iroha` and `iroha-2-contributors`.
+The Discord and Telegram channels are synchronised, and users of both channels see your messages.
+
+Finally, you can [create](https://github.com/hyperledger/iroha/issues/new/choose) a GitHub issue, whether it's a request to update documentation, a suggestion for the core team, or a bug you have found.

--- a/src/guide/support.md
+++ b/src/guide/support.md
@@ -1,7 +1,7 @@
 # Receive support
 
 From time to time, you may have questions about Iroha that you would like to discuss in detail with others.
-There are three ways to quickly get in touch with our community: Telegram, Discord and GitHub.
+There are three ways to quickly get in touch with our community: Telegram, Discord, and GitHub.
 
 A large part of the community currently uses [Telegram](https://t.me/hyperledgeriroha) for communication.
 The Hyperledger part of the team prefers [Discord](https://discord.gg/hyperledger), with two dedicated channels: `iroha` and `iroha-2-contributors`.

--- a/src/guide/support.md
+++ b/src/guide/support.md
@@ -7,4 +7,4 @@ A large part of the community currently uses [Telegram](https://t.me/hyperledger
 The Hyperledger part of the team prefers [Discord](https://discord.gg/hyperledger), with two dedicated channels: `iroha` and `iroha-2-contributors`.
 The Discord and Telegram channels are synchronized, so users of both media see your messages.
 
-Finally, you can [create](https://github.com/hyperledger/iroha/issues/new/choose) a GitHub issue, whether it's a request to update documentation, a suggestion for the core team, or a bug you have found.
+Finally, you can [create a GitHub issue](https://github.com/hyperledger/iroha/issues/new/choose), whether it's a request to update documentation, a suggestion for the core team, or a bug you have found.


### PR DESCRIPTION
As mentioned in #249, I'd like to add the support channels in the documentation, so the users can contact us more quickly.

Closes #249 

Signed-off-by: 6r1d <vic.6r1d@gmail.com>