### PR TITLE
[feature] #286: link `api_spec` from the core repo

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -296,6 +296,7 @@ const BASE = process.env.PUBLIC_PATH ?? '/'
 export default defineConfig({
   base: BASE,
   srcDir: 'src',
+  srcExclude: ['snippets/*.md'],
   title: 'Hyperledger Iroha 2 Tutorial',
   description:
     'Documentation for Hyperledger Iroha 2 offering step-by-step guides for SDKs and outlining the main differences between Iroha versions.',

--- a/etc/cli.ts
+++ b/etc/cli.ts
@@ -35,7 +35,7 @@ async function processSnippet(
     return 'skipped'
   }
 
-  const fileContent: string = await match(parsed.source)
+  const fileContent: string = await match<typeof parsed.source, Promise<string>>(parsed.source)
     .with({ type: 'fs' }, async ({ path: snippetPath }) => {
       return fs.readFile(snippetPath, { encoding: 'utf-8' })
     })
@@ -46,6 +46,7 @@ async function processSnippet(
       })
     })
     .exhaustive()
+    .then((content) => parsed.transform?.(content) ?? content)
 
   await fs.writeFile(writePath, fileContent)
 

--- a/etc/snippet_sources.ts
+++ b/etc/snippet_sources.ts
@@ -127,7 +127,11 @@ export default [
   {
     src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/docs/source/references/api_spec.md`,
     filename: `iroha2_dev_api_spec.md`,
-    transform: rewriteMdLinks(`https://github.com/hyperledger/iroha/tree/${IROHA_REV_DEV}/docs/sources/references/`),
+    transform: (source) =>
+      Promise.resolve(source)
+        .then(rewriteMdLinks(`https://github.com/hyperledger/iroha/tree/${IROHA_REV_DEV}/docs/sources/references/`))
+        // remove the title header (`# ...`)
+        .then((x) => x.replace(/# .+\n/m, '')),
   },
   {
     src: './src/example_code/lorem.rs',

--- a/etc/snippet_sources.ts
+++ b/etc/snippet_sources.ts
@@ -8,7 +8,7 @@ const IROHA_REV_STABLE = 'c4af68c4f7959b154eb5380aa93c894e2e63fe4e'
 /**
  * hyperledger/iroha#iroha2-dev
  */
-const IROHA_REV_DEV = '5310dd4c5467c526570177d6b770ebdf0fbf79ea'
+const IROHA_REV_DEV = '726f5eabf65a79ea618b4fce62a09cee7a5b13d1'
 
 /**
  * hyperledger/iroha-javascript#iroha2
@@ -122,6 +122,10 @@ export default [
   {
     src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_STABLE}/MAINTAINERS.md`,
     filename: 'iroha-maintainers-at-stable.md',
+  },
+  {
+    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/docs/source/references/api_spec.md`,
+    filename: `iroha2_dev_api_spec.md`,
   },
   {
     src: './src/example_code/lorem.rs',

--- a/etc/snippet_sources.ts
+++ b/etc/snippet_sources.ts
@@ -1,4 +1,5 @@
 import type { SnippetSourceDefinition } from './types'
+import { rewriteMdLinks } from './util'
 
 /**
  * hyperledger/iroha#iroha2-stable
@@ -126,6 +127,7 @@ export default [
   {
     src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/docs/source/references/api_spec.md`,
     filename: `iroha2_dev_api_spec.md`,
+    transform: rewriteMdLinks(`https://github.com/hyperledger/iroha/tree/${IROHA_REV_DEV}/docs/sources/references/`),
   },
   {
     src: './src/example_code/lorem.rs',

--- a/etc/types.ts
+++ b/etc/types.ts
@@ -12,4 +12,8 @@ export interface SnippetSourceDefinition {
    * (Optional) The name that the source file will have in the snippets directory.
    */
   filename?: string
+  /**
+   * **Advanced:** transform loaded content before writing it in the snippets directory
+   */
+  transform?: (content: string) => string | Promise<string>
 }

--- a/etc/util.spec.ts
+++ b/etc/util.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'vitest'
 import { SnippetSourceDefinition } from './types'
-import { ParseDefinitionResult, parseSnippetSrc, parseDefinition } from './util'
+import { ParseDefinitionResult, parseSnippetSrc, parseDefinition, rewriteMdLinks } from './util'
 
 describe('Parse snippet src', () => {
   test.each([
@@ -14,12 +14,32 @@ describe('Parse snippet src', () => {
 
 describe('Parse snippet source definition', () => {
   test.each([
-    [{ src: './hey' }, { type: 'ok', saveFilename: 'hey', source: { type: 'fs', path: './hey' } }],
+    [{ src: './hey' }, { type: 'ok', saveFilename: 'hey', source: { type: 'fs', path: './hey' }, transform: null }],
     [
       { src: 'https://github.com/file.ts', filename: 'override.ts' },
-      { type: 'ok', source: { type: 'hyper', url: 'https://github.com/file.ts' }, saveFilename: 'override.ts' },
+      {
+        type: 'ok',
+        source: { type: 'hyper', url: 'https://github.com/file.ts' },
+        saveFilename: 'override.ts',
+        transform: null,
+      },
     ],
-  ] as [SnippetSourceDefinition, ParseDefinitionResult][])('Parses %o to %o', (input, output) => {
+  ] satisfies [SnippetSourceDefinition, ParseDefinitionResult][])('Parses %o to %o', (input, output) => {
     expect(parseDefinition(input)).toEqual(output)
+  })
+})
+
+describe('links rewrite', () => {
+  const BASE = 'https://github.com/a/b/c/d/e/f'
+
+  test('./config.md', () => {
+    expect(rewriteMdLinks(BASE)(`[cfg](./config.md)`)).toMatchInlineSnapshot(
+      '"[cfg](https://github.com/a/b/c/d/e/f/config.md)"',
+    )
+  })
+  test('../../../client#foo', () => {
+    expect(rewriteMdLinks(BASE)(`[foo](../../../client#foo)`)).toMatchInlineSnapshot(
+      '"[foo](https://github.com/a/b/c/client#foo)"',
+    )
   })
 })

--- a/src/api/index.md
+++ b/src/api/index.md
@@ -1,4 +1,18 @@
-# API
+<script setup>
+import { useData } from 'vitepress'
 
-Refer to
-[API Specification](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/api_spec.md).
+const { page } = useData()
+</script>
+
+::: info
+
+This page contains the `api_spec.md` right from
+`hyperledger/iroha#iroha2-dev`. You can read the most up-to-date version of
+it on
+[GitHub](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/api_spec.md).
+
+Please note that this page was last updated at <b>{{ new Date(page.lastUpdated).toLocaleString() }}</b>.
+
+:::
+
+<!--@include: ../snippets/iroha2_dev_api_spec.md -->

--- a/src/api/index.md
+++ b/src/api/index.md
@@ -6,7 +6,7 @@ const { page } = useData()
 
 ::: info
 
-This page contains the `api_spec.md` right from
+This page contains the copy of `api_spec.md` from
 `hyperledger/iroha#iroha2-dev`. You can read the most up-to-date version of
 it on
 [GitHub](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/api_spec.md).

--- a/src/api/index.md
+++ b/src/api/index.md
@@ -6,12 +6,12 @@ const { page } = useData()
 
 ::: info
 
-This page contains the copy of `api_spec.md` from
+This page contains a copy of `api_spec.md` from
 `hyperledger/iroha#iroha2-dev`. You can read the most up-to-date version of
 it on
 [GitHub](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/api_spec.md).
 
-Please note that this page was last updated at <b>{{ new Date(page.lastUpdated).toLocaleString() }}</b>.
+Please note this page was last updated on <b>{{ new Date(page.lastUpdated).toLocaleString() }}</b>.
 
 :::
 

--- a/src/api/index.md
+++ b/src/api/index.md
@@ -4,6 +4,8 @@ import { useData } from 'vitepress'
 const { page } = useData()
 </script>
 
+# API Specification
+
 ::: info
 
 This page contains a copy of `api_spec.md` from


### PR DESCRIPTION
Close #286

Things to resolve:

- [x] Included markdown contains some dead links (e.g. `../../client`) which don't seamlessly integrate with our docs. Should we update the upstream source?
- [x] Document title is rendered not nicely
- [x] Ignore `snippets` directory in Vitepress' `*.md` scanning to avoid building of unnecessary pages.