### PR TITLE
[chore] #289: add iroha_client_cli build link

### DIFF
--- a/src/guide/bash.md
+++ b/src/guide/bash.md
@@ -77,7 +77,7 @@ make do with what one has.
 ## 1. Iroha 2 Client Setup
 
 Note, first, that we have already created the `iroha_client_cli` binary
-executable, when we ran the build command.
+executable, when we [ran the `build` command](./build.md#build-iroha-client).
 
 Create a fresh directory for the client:
 


### PR DESCRIPTION
People can start with the Bash guide; however small this change is, it may help reduce confusion.

Closes #289 