### PR TITLE
[chore]: fix typo in path to `api_spec` on GitHub

### DIFF
--- a/etc/snippet_sources.ts
+++ b/etc/snippet_sources.ts
@@ -129,7 +129,7 @@ export default [
     filename: `iroha2_dev_api_spec.md`,
     transform: (source) =>
       Promise.resolve(source)
-        .then(rewriteMdLinks(`https://github.com/hyperledger/iroha/tree/${IROHA_REV_DEV}/docs/sources/references/`))
+        .then(rewriteMdLinks(`https://github.com/hyperledger/iroha/tree/${IROHA_REV_DEV}/docs/source/references/`))
         // remove the title header (`# ...`)
         .then((x) => x.replace(/# .+\n/m, '')),
   },


### PR DESCRIPTION
There was a typo in path which led to 404:

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/43530070/226792425-a697af05-9cdd-4ac5-8ca8-0cfa3f35b3a5.png">
