### PR TITLE
[chore] #295: add XDG specification link

### DIFF
--- a/src/guide/rust.md
+++ b/src/guide/rust.md
@@ -99,7 +99,7 @@ is hidden behind interior mutable smart pointers.
 Of course, depending on your application, you might want to de-serialise
 your `ClientConfiguration` structure from a different location. Perhaps,
 you might want to build the configuration in place using the command-line
-arguments, or perhaps, you're using the XDG specification to store the file
+arguments, or perhaps, you're using the [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html) to store the file
 persistently in a different location. For this purpose, it's useful to try
 and construct an instance of `ClientConfiguration`:
 


### PR DESCRIPTION
As stated in https://github.com/hyperledger/iroha-2-docs/issues/295, we should add a link to the XDG specification if someone needs to get acquainted with it.

---


Moreover, a footnote telling which variable in the spec would be helpful. For example, we can write that `iroha_client_cli` will look for `$XDG_CONFIG_HOME`.
Iroha doesn't start on my machine right now, while digging in the source shows [this code](https://github.com/hyperledger/iroha/blob/726f5eabf65a79ea618b4fce62a09cee7a5b13d1/client_cli/src/main.rs#L141-L142).

So far, I've tried this code to see that it shows a subdirectory relative to the current working dir.

```rust
#![allow(unused)]
#![feature(absolute_path)]
#[cfg(unix)]
fn main() -> std::io::Result<()> {
  use std::path::{self, Path};

  let absolute = path::absolute("config")?;
  println!("{}", absolute.display());
  Ok(())
}
```

Could someone explain how the config lookup works to me? I understand one of the possible paths is the config subdirectory relative to a current one, but where do we look for XDG paths?