### PR TITLE
Update Rust SDK version (related to #308)

### DIFF
--- a/src/guide/rust.md
+++ b/src/guide/rust.md
@@ -43,10 +43,10 @@ meantime, you could use the local copy that you've just created in the
 
 ```toml
 [dependencies]
-iroha_client = { version = "=2.0.0-pre-rc.11", path = "~/Git/iroha/client" }
-iroha_data_model = { version = "=2.0.0-pre-rc.11", path = "~/Git/iroha/data_model" }
-iroha_crypto = { version = "=2.0.0-pre-rc.11", path = "~/Git/iroha/crypto" }
-iroha_config = { version = "=2.0.0-pre-rc.11", path = "~/Git/iroha/config" }
+iroha_client = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/client" }
+iroha_data_model = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/data_model" }
+iroha_crypto = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/crypto" }
+iroha_config = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/config" }
 ```
 
 The added benefit of using a local copy is that you have access to the


### PR DESCRIPTION
We mention old release candidate versions in some places, and while it's not a priority, how about adding this change?
Maybe we can refer to `rc.15` at this point, but I am using https://github.com/hyperledger/iroha/blob/iroha2-dev/client_cli/Cargo.toml as a reference for now.