### PR TITLE
[chore] Fix client config path (#358)

### DIFF
--- a/src/guide/bash.md
+++ b/src/guide/bash.md
@@ -88,7 +88,7 @@ $ mkdir -p test_docker
 Copy the configuration file to the client directory:
 
 ```bash
-$ cp ./configs/client_cli/config.json test_docker/
+$ cp ./configs/client/config.json test_docker/
 ```
 
 ::: tip

--- a/src/guide/python.md
+++ b/src/guide/python.md
@@ -47,7 +47,7 @@ $ pip install ./target/wheels/iroha_python-*.whl
 Finally, you will need a working client configuration:
 
 ```bash
-$ cp -vfr ~/Git/iroha/configs/client_cli/config.json example/config.json
+$ cp -vfr ~/Git/iroha/configs/client/config.json example/config.json
 ```
 
 ::: tip

--- a/src/guide/rust.md
+++ b/src/guide/rust.md
@@ -69,7 +69,7 @@ configurations in the `~/Git/iroha/configs` folder.
 So let's copy the example client configuration somewhere useful:
 
 ```bash
-$ cp -vfr ~/Git/iroha/configs/client_cli/config.json example/config.json
+$ cp -vfr ~/Git/iroha/configs/client/config.json example/config.json
 ```
 
 We recommend looking through it to familiarise yourself with the key pieces


### PR DESCRIPTION
`cp ./configs/client_cli/config.json test_docker/` command won't work anymore; `cp ./configs/client/config.json test_docker/` would work in `iroha2-dev`, `dae3113496`.

I wonder if we need to do something about the Java and JavaScript articles, as `config.json` is mentioned there briefly, but Bash is the first thing to try. I think I will update those as well.