### PR TITLE
Security: Navigation and bad syntax bug fix

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -156,7 +156,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
             },
             {
               text: 'Storing Cryptographic Keys',
-              link: '/guide/security/generating-cryptographic-keys.md',
+              link: '/guide/security/storing-cryptographic-keys.md',
             },
           ],
         },

--- a/src/guide/security/generating-cryptographic-keys.md
+++ b/src/guide/security/generating-cryptographic-keys.md
@@ -208,7 +208,7 @@ To make the `<username>/.local/bin` directory explicitly available to your shell
     $ fish_add_path ~/.local/bin
     ```
 
-::: note
+::: info
 
 In addition to the methods listed above, consult documentation for the shell you're using or consider adding the `PATH` variant to your terminal's session configuration.
 


### PR DESCRIPTION
## Fixed:
- The **Storing Cryptographic Keys** topic was inaccessible for users due to `.vitepress/config.mts` containing a typo, which resulted in both the **Generating Cryptographic Keys** and **Storing Cryptographic Keys** buttons of the navbar leading to the **Generating Cryptographic Keys** topic.
- A case of bad VitePress-related syntax, which resulted in the hosted HTML page containing an unformatted custom container.