### PR TITLE
[docs] Suggest using ~/hyperledger instead of ~/Git

### DIFF
--- a/src/guide/advanced/running-iroha-on-bare-metal.md
+++ b/src/guide/advanced/running-iroha-on-bare-metal.md
@@ -67,11 +67,11 @@ you should build it in `--release` mode.
 We want to make sure that we have the right configuration.
 
 There are different ways to do this. You can copy the contents of the
-`~/Git/iroha/configs/peer/` into a new directory, or, alternatively, just
+`~/hyperledger/iroha/configs/peer/` into a new directory, or, alternatively, just
 run all commands from that directory:
 
 ```bash
-$ cd ~/Git/iroha/configs/peer
+$ cd ~/hyperledger/iroha/configs/peer
 ```
 
 The third option is to specify the full path to the configuration file in
@@ -129,8 +129,8 @@ This process is almost universally unreliable and messy, and it is likely
 that your system is special in that it breaks some of our assumptions.
 
 If the above optional steps didn’t work for you, you can keep working in
-the `~/Git/iroha/configs/peer/` folder, and run Iroha via
-`~/Git/iroha/target/debug/iroha`.
+the `~/hyperledger/iroha/configs/peer/` folder, and run Iroha via
+`~/hyperledger/iroha/target/debug/iroha`.
 
 This makes the command-line a little harder to read, which is why we
 recommend setting up your environment first.
@@ -154,19 +154,19 @@ This is the recommended method of bringing up an Iroha peer. What we do is:
 1. Create a new directory for the configuration files:
 
    ```bash
-   $ mkdir -p ~/Git/iroha/deploy
+   $ mkdir -p ~/hyperledger/iroha/deploy
    ```
 
 2. Copy the `peer` configuration into it:
 
    ```bash
-   $ cp -vfr ~/Git/iroha/configs/peer/*.json ~/Git/iroha/deploy
+   $ cp -vfr ~/hyperledger/iroha/configs/peer/*.json ~/hyperledger/iroha/deploy
    ```
 
 3. Copy the respective Iroha binary into your binary folder:
 
    ```bash
-   $ sudo cp -vfr ~/Git/iroha/target/debug/iroha /usr/bin/
+   $ sudo cp -vfr ~/hyperledger/iroha/target/debug/iroha /usr/bin/
    ```
 
    which will install Iroha 2 system wide.
@@ -462,7 +462,7 @@ Iroha in the real world.
     running
 
     ```bash
-    $ ~/Git/iroha/target/release/iroha
+    $ ~/hyperledger/iroha/target/release/iroha
     ```
 
 ::: info Note

--- a/src/guide/get-started/bash.md
+++ b/src/guide/get-started/bash.md
@@ -35,7 +35,7 @@ It only looks for a configuration file in one of two places:
 1. If the `-c` or `--config` command line flag is specified, the next
    argument interpreted as a path.
 
-   For example: `-c ~/Git/iroha/configs/peer/config.json`. If that file
+   For example: `-c ~/hyperledger/iroha/configs/peer/config.json`. If that file
    doesn't exist, you will see an error, and `iroha_client_cli` won't look
    for a configuration file anywhere else.
 
@@ -127,7 +127,7 @@ the pipeline events as they are output.
 On a new terminal tab run:
 
 ```bash
-$ cd ~/Git/iroha/test_docker
+$ cd ~/hyperledger/iroha/test_docker
 ```
 
 If you followed the steps correctly, this should contain the

--- a/src/guide/get-started/build.md
+++ b/src/guide/get-started/build.md
@@ -49,7 +49,7 @@ the setup process. Just go with the defaults.
    [here](./install.md#install-iroha-from-github), run:
 
    ```bash
-   $ cd ~/Git/iroha
+   $ cd ~/hyperledger/iroha
    ```
 
 2. Build the Iroha 2 client using:

--- a/src/guide/get-started/install.md
+++ b/src/guide/get-started/install.md
@@ -51,25 +51,24 @@ for details.
     Iroha 2, to keep things tidy.
 
     ```bash
-    $ mkdir -p ~/Git
+    $ mkdir -p ~/hyperledger
     ```
 
     ::: tip
+    Previously the docs mentioned `~/Git` directory instead of `~/hyperledger`. If you already have a working installation, consider moving it to the new directory:
 
-    On macOS, if you get
-    `fatal: could not create work tree dir 'iroha': Read-only file system`,
-    that’s because the home folder is not a real file system. The fix is to
-    create the `Git` folder.
-
+    ```bash
+    $ mv ~/Git ~/hyperledger
+    ```
     :::
 
 2.  Enter the directory you have just created using
 
     ```bash
-    $ cd ~/Git
+    $ cd ~/hyperledger
     ```
 
-3.  Then `clone` the Iroha git repository into the folder `~/Git/iroha` and
+3.  Then `clone` the Iroha git repository into the folder `~/hyperledger/iroha` and
     `checkout` the branch you prefer to work on. You can use the
     `iroha2-lts` branch, which is the long-term support release, or the
     latest stable release branch (`iroha2-stable`). To clone the repository

--- a/src/guide/get-started/python.md
+++ b/src/guide/get-started/python.md
@@ -25,7 +25,7 @@ Let's create a separate folder for Iroha Python and clone its GitHub
 repository into it:
 
 ```bash
-$ cd ~/Git/
+$ cd ~/hyperledger/
 $ git clone https://github.com/hyperledger/iroha-python/ --branch iroha2
 $ cd iroha-python
 ```
@@ -47,7 +47,7 @@ $ pip install ./target/wheels/iroha_python-*.whl
 Finally, you will need a working client configuration:
 
 ```bash
-$ cp -vfr ~/Git/iroha/configs/client/config.json example/config.json
+$ cp -vfr ~/hyperledger/iroha/configs/client/config.json example/config.json
 ```
 
 ::: tip

--- a/src/guide/get-started/rust.md
+++ b/src/guide/get-started/rust.md
@@ -43,10 +43,10 @@ meantime, you could use the local copy that you've just created in the
 
 ```toml
 [dependencies]
-iroha_client = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/client" }
-iroha_data_model = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/data_model" }
-iroha_crypto = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/crypto" }
-iroha_config = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/config" }
+iroha_client = { version = "=2.0.0-pre-rc.13", path = "~/hyperledger/iroha/client" }
+iroha_data_model = { version = "=2.0.0-pre-rc.13", path = "~/hyperledger/iroha/data_model" }
+iroha_crypto = { version = "=2.0.0-pre-rc.13", path = "~/hyperledger/iroha/crypto" }
+iroha_config = { version = "=2.0.0-pre-rc.13", path = "~/hyperledger/iroha/config" }
 ```
 
 The added benefit of using a local copy is that you have access to the
@@ -64,12 +64,12 @@ but not via crates.io.
 :::
 
 You would also benefit from having immediate access to the example
-configurations in the `~/Git/iroha/configs` folder.
+configurations in the `~/hyperledger/iroha/configs` folder.
 
 So let's copy the example client configuration somewhere useful:
 
 ```bash
-$ cp -vfr ~/Git/iroha/configs/client/config.json example/config.json
+$ cp -vfr ~/hyperledger/iroha/configs/client/config.json example/config.json
 ```
 
 We recommend looking through it to familiarise yourself with the key pieces


### PR DESCRIPTION
The current documentation does an excellent job providing an end-to-end setup experience. 

However, the choice of `~/Git` for the project directory stands out as overly generic. 

In the spirit of continuous improvement and clarity, I suggest adopting `~/hyperledger` as a project directory. This name is not only more specific but also accurately reflects the project's association with the Hyperledger ecosystem.

### Changes Summary
- Change `~/Git` to `~/hyperledger`
- Mention previously used directory and provide a clear way to transition
- Remove the TIP suggesting creating `~/Git` directory 