### PR TITLE
Update the data model reference to the latest iroha dev revision

### DIFF
--- a/etc/meta.ts
+++ b/etc/meta.ts
@@ -1,7 +1,7 @@
 /**
  * hyperledger/iroha#iroha2-dev
  */
-export const IROHA_REV_DEV = '50fc8baccc3c657b3cc3c926772d71b61040e2a8'
+export const IROHA_REV_DEV = 'e7a605c1a926c319d214ef3825524ee6c2e9f076'
 
 /**
  * hyperledger/iroha-javascript#iroha2 (rc13)

--- a/etc/schema/render.ts
+++ b/etc/schema/render.ts
@@ -161,6 +161,22 @@ function renderSegment(segment: Segment, segmentName: string): string {
       ),
     )
     .with(null, () => segmentType('Zero-Size Type (unit type, null type)'))
+    .with({ Bitmap: P.select() }, ({ repr, masks }) =>
+      joinDouble(
+        // .
+        segmentType('Bitmap'),
+        segmentProp('Repr', repr),
+        segmentPropNameOnly('Masks'),
+        table(
+          [
+            { title: 'Field name', align: 'right' },
+            { title: 'Field value', align: 'left' },
+          ],
+          masks.map((x) => [code(x.name), code('0x' + x.mask.toString(16))]),
+          { indent: '  ' },
+        ),
+      ),
+    )
     .exhaustive()
 
   return joinDouble(heading, body)

--- a/etc/schema/types.ts
+++ b/etc/schema/types.ts
@@ -17,6 +17,7 @@ export type SchemaTypeDefinition =
   | IntDefinition
   | FixedPointDefinition
   | TupleDef
+  | BitmapDef
 
 export interface MapDefinition {
   Map: {
@@ -77,3 +78,15 @@ export interface FixedPointDefinition {
 export type TypePath = string
 
 export type UnitType = null
+
+export interface BitmapMask {
+  name: string
+  mask: number
+}
+
+export interface BitmapDef {
+  Bitmap: {
+    repr: string
+    masks: Array<BitmapMask>
+  }
+}

--- a/etc/snippet-sources.ts
+++ b/etc/snippet-sources.ts
@@ -116,15 +116,15 @@ export default [
     src: './src/example_code/lorem.rs',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/client/config.json`,
-    filename: 'client-cli-config.json',
+    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/client.template.toml`,
+    filename: 'client-cli-config-template.toml',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/peer/config.json`,
-    filename: 'peer-config.json',
+    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/peer.template.toml`,
+    filename: 'peer-config-template.toml',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/peer/genesis.json`,
+    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/swarm/genesis.json`,
   },
   {
     src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/client/examples/tutorial.rs`,

--- a/src/guide/configure/client-configuration.md
+++ b/src/guide/configure/client-configuration.md
@@ -2,9 +2,9 @@
 
 Let's look at the client configuration options.
 
-::: details Client configuration example
+::: details Client configuration template
 
-<<< @/snippets/client-cli-config.json
+<<< @/snippets/client-cli-config-template.toml
 
 :::
 

--- a/src/guide/configure/peer-configuration.md
+++ b/src/guide/configure/peer-configuration.md
@@ -5,9 +5,9 @@ your blockchain operates.
 
 Here's an example of how peer configuration file looks like:
 
-::: details Peer configuration example
+::: details Peer configuration template
 
-<<< @/snippets/peer-config.json
+<<< @/snippets/peer-config-template.toml
 
 :::
 

--- a/src/guide/configure/sample-configuration.md
+++ b/src/guide/configure/sample-configuration.md
@@ -11,10 +11,10 @@ Here you can find sample configuration files for Iroha 2:
 
 ::: code-group
 
-<<< @/snippets/peer-config.json
+<<< @/snippets/peer-config-template.toml
 
 <<< @/snippets/genesis.json
 
-<<< @/snippets/client-cli-config.json
+<<< @/snippets/client-cli-config-template.toml
 
 :::

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -552,7 +552,7 @@ It is also possible to retrieve the data of a specific `struct` group or variabl
 
 This endpoint expects the following data:
 
-  - **Body**: [`VersionedSignedTransaction`](/reference/data-model-schema#versionedsignedtransaction)
+  - **Body**: [`SignedTransaction`](/reference/data-model-schema#signedtransaction)
 
 #### Responses
 

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -319,29 +319,39 @@ A `GET` request to the endpoint.
 
 #### Requests
 
-This endpoint expects the following data:
+This endpoint expects requests with two shapes:
 
-  - **Body**: [`VersionedSignedQuery`](/reference/data-model-schema#versionedsignedquery)
-  - **Parameters** (optional):
-    - `start` — Specifies the `id` of a starting entry. A successful response will contain all entries newer than and including the `id` specified.\
-    - `limit` — Specifies the exact number of retrieved `id` entries.\
-    - `sort_by_metadata_key` — Specifies the metadata key of the `id` entries that will be returned.\
-    - `fetch_size` — Specifies the maximum number of results that a response can contain.
+Start a query:
+
+- **Body**: [`SignedQuery`](/reference/data-model-schema#signedquery)
+
+OR
+
+Get the next batch of a previously started query:
+
+- **Parameters**:
+    - `cursor` - specifies a cursor previously returned as part of query response
+
+Request
 
 #### Responses
 
-| Code | Response         | Body                                                                                             |
-| :--: | ---------------- | ------------------------------------------------------------------------------------------------ |
-| 200  | Success          | [`VersionedBatchedResponse<Value>`](/reference/data-model-schema#versionedbatchedresponse-value) |
-| 400  | Conversion Error | [`QueryExecutionFail::Conversion(String)`](/reference/data-model-schema#queryexecutionfail)      |
-| 400  | Evaluate Error   | [`QueryExecutionFail::Evaluate(String)`](/reference/data-model-schema#queryexecutionfail)        |
-| 401  | Signature Error  | [`QueryExecutionFail::Signature(String)`](/reference/data-model-schema#queryexecutionfail)       |
-| 403  | Permission Error | [`QueryExecutionFail::Permission(String)`](/reference/data-model-schema#queryexecutionfail)      |
-| 404  | Find Error       | [`QueryExecutionFail::Find(FindError)`](/reference/data-model-schema#queryexecutionfail)         |
+| Code | Response                        | Body                                                                                               | Description                                                                |
+|:----:|---------------------------------|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| 200  | Success                         | [`BatchedResponse<QueryOutputBox>`](/reference/data-model-schema#batchedresponse-queryoutputbox)   | Successful query request                                                   |
+| 400  | Conversion Error                | [`QueryExecutionFail::Conversion(String)`](/reference/data-model-schema#queryexecutionfail)        | Invalid asset query for the actual asset type                              |
+| 400  | Cursor Error                    | [`QueryExecutionFail::UnknownCursor`](/reference/data-model-schema#queryexecutionfail)             | An invalid cursor was provided in the batch request                        |
+| 400  | FetchSizeTooBig Error           | [`QueryExecutionFail::FetchSizeTooBig`](/reference/data-model-schema#queryexecutionfail)           | Fetch size specified in the query request is too large                     |
+| 400  | InvalidSingularParameters Error | [`QueryExecutionFail::InvalidSingularParameters`](/reference/data-model-schema#queryexecutionfail) | Specified query parameters are not applicable to the (singular) query type |
+| 401  | Signature Error                 | [`QueryExecutionFail::Signature(String)`](/reference/data-model-schema#queryexecutionfail)         | The signature on the query is incorrect                                    |
+| 403  | Permission Error                | [`QueryExecutionFail::Permission(String)`](/reference/data-model-schema#queryexecutionfail)        | The user does not have permission to execute this query                    |
+| 404  | Find Error                      | [`QueryExecutionFail::Find(FindError)`](/reference/data-model-schema#queryexecutionfail)           | The queried object was not found                                           |
 
 ::: info
 
-The `200 Success` response returns results that are ordered by `id`, which use Rust's [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) and [Ord](https://doc.rust-lang.org/std/cmp/trait.Ord.html) traits.
+The `200 Success` response returns results that are ordered by `id`, which use
+Rust's [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
+and [Ord](https://doc.rust-lang.org/std/cmp/trait.Ord.html) traits.
 
 :::
 


### PR DESCRIPTION
This PR does three things:
- support for bitmaps in schema (introduced in https://github.com/hyperledger/iroha/pull/4381)
- "fixes" paths to referenced config files
- updates torii reference to be in line with https://github.com/hyperledger/iroha/pull/4544

While the inclusion of toml templates in place of old json files makes the config documentation "wrong", this allows writing new documentation with references to a more up-to-date `schema.json`.

In the end I think the #397 will in the end remove the toml templates altogether, I consider this just a way to unblock my updates to the torii reference for https://github.com/hyperledger/iroha/pull/4544

@0x009922 Do you think it's a good approach? Or should we try somehow to keep the old `json`'s in place while the new config reference is not yet complete?