### PR TITLE
Rename crates iroha_cli and iroha_kagami

### DIFF
--- a/src/guide/get-started/install-iroha-2.md
+++ b/src/guide/get-started/install-iroha-2.md
@@ -65,11 +65,11 @@ To get started you need two of the binaries shipped with Iroha:
 - `iroha`, the main command line tool for accessing the Iroha network as a user. It allows you to manage domains, accounts, and assets, and to query network status and events. To install `iroha` system-wide, use the following command:
 
 ```bash
-$ cargo install --git https://github.com/hyperledger/iroha.git iroha_client_cli
+$ cargo install --git https://github.com/hyperledger/iroha.git iroha_cli
 ```
 
 - `kagami`, the tool that generates cryotpgraphic keys, configuration files and other necessary data. To install `kagami` system-wide, use the following command:
 
 ```bash
-$ cargo install --git https://github.com/hyperledger/iroha.git kagami
+$ cargo install --git https://github.com/hyperledger/iroha.git iroha_kagami
 ```


### PR DESCRIPTION
`iroha_client_cli` and `kagami` were renamed in https://github.com/hyperledger/iroha/pull/4970