### PR TITLE
Fix Vercel deployment and verify translations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .vitepress/dist
 .vitepress/cache
+.vitepress/.temp
 .vercel

--- a/.github/workflows/gh-pages-deploy.yaml
+++ b/.github/workflows/gh-pages-deploy.yaml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -45,6 +45,7 @@ jobs:
         run: |
           pnpm build
           pnpm cli validate-links .vitepress/dist --public-path /iroha-docs/
+          pnpm cli validate-locales .vitepress/dist --public-path /iroha-docs/
         env:
           FORCE_COLOR: 2
           PUBLIC_PATH: /iroha-docs/
@@ -65,3 +66,53 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+
+  verify-production:
+    runs-on: ubuntu-latest
+    needs: deploy
+    timeout-minutes: 6
+    steps:
+      - name: Check for a superseding deployment
+        id: current
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          current_sha="$(
+            curl --fail --silent --show-error \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/commits/main" |
+              jq --raw-output .sha
+          )"
+          if [[ "$current_sha" != "$GITHUB_SHA" ]]; then
+            echo "Commit $GITHUB_SHA was superseded by $current_sha; skipping canonical verification."
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify canonical deployment
+        if: steps.current.outputs.superseded != 'true'
+        env:
+          EXPECTED_REVISION: ${{ github.sha }}
+          SITE_URL: https://docs.iroha.tech
+        run: |
+          deadline=$((SECONDS + 300))
+          attempt=0
+          while ((SECONDS < deadline)); do
+            attempt=$((attempt + 1))
+            html="$(curl --connect-timeout 3 --max-time 5 --fail --silent --show-error "$SITE_URL/" || true)"
+            if [[ "$html" == *"iroha-docs-revision"* ]] && \
+               [[ "$html" == *"$EXPECTED_REVISION"* ]] && \
+               [[ "$html" == *"VPNavBarTranslations"* ]] && \
+               curl --connect-timeout 3 --max-time 5 --fail --silent --show-error --output /dev/null "$SITE_URL/es/"; then
+              echo "Canonical deployment is current and exposes translated navigation."
+              exit 0
+            fi
+            echo "Attempt $attempt: waiting for canonical deployment $EXPECTED_REVISION"
+            if ((SECONDS + 10 >= deadline)); then
+              break
+            fi
+            sleep 10
+          done
+
+          echo "::error::Canonical site did not publish $EXPECTED_REVISION with translated navigation."
+          exit 1

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -49,13 +49,18 @@ jobs:
         env:
           FORCE_COLOR: 2
 
+      - name: Validate language selector
+        run: pnpm cli validate-locales .vitepress/dist
+
       - name: Build GitHub Pages backup
         run: pnpm build
         env:
           FORCE_COLOR: 2
           PUBLIC_PATH: /iroha-docs/
 
-      - name: Validate GitHub Pages backup links
-        run: pnpm cli validate-links .vitepress/dist --public-path /iroha-docs/
+      - name: Validate GitHub Pages backup
+        run: |
+          pnpm cli validate-links .vitepress/dist --public-path /iroha-docs/
+          pnpm cli validate-locales .vitepress/dist --public-path /iroha-docs/
         env:
           FORCE_COLOR: 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 /src/flymd.html
 /src/*.temp
 .vitepress/cache
+.vitepress/.temp
 
 # Local IDE settings.
 .idea

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .vitepress/dist
 .vitepress/cache
+.vitepress/.temp
 .vercel
 /src/public/openapi
 /src/snippets

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import { DefaultTheme, defineConfig } from 'vitepress'
+import { DefaultTheme, defineConfig, type HeadConfig } from 'vitepress'
 import footnote from 'markdown-it-footnote'
 import { resolve } from 'path'
 import ViteSvgLoader from 'vite-svg-loader'
@@ -17,6 +17,7 @@ import {
   type DocsLocale,
   type NavigationLabels,
 } from '../etc/locales'
+import { renderSearchHeadings, splitSearchHeadings } from '../etc/search-index'
 
 function nav(
   labels: NavigationLabels = ROOT_LOCALE.navigation,
@@ -508,12 +509,17 @@ const THEME_LOCALES = Object.fromEntries(
 
 const PUBLIC_BASE = process.env.PUBLIC_PATH ?? '/'
 const publicAsset = (name: string): string => `${PUBLIC_BASE}${name}`
+const BUILD_REVISION = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA
+const revisionHead: HeadConfig[] = BUILD_REVISION
+  ? [['meta', { name: 'iroha-docs-revision', content: BUILD_REVISION }]]
+  : []
 
 export default defineConfig({
   base: PUBLIC_BASE,
   srcDir: 'src',
   srcExclude: ['snippets/*.md'],
-  buildConcurrency: 4,
+  buildConcurrency: 2,
+  metaChunk: true,
   cleanUrls: false,
   locales: SITE_LOCALES,
   title: 'Hyperledger Iroha 3 Docs',
@@ -538,6 +544,7 @@ export default defineConfig({
   lastUpdated: true,
 
   head: [
+    ...revisionHead,
     // Based on: https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs
     ['link', { rel: 'icon', href: publicAsset('favicon.ico'), sizes: 'any' }],
     ['link', { rel: 'icon', href: publicAsset('icon.svg'), sizes: 'image/svg+xml' }],
@@ -609,7 +616,9 @@ export default defineConfig({
           options: {
             fields: ['title', 'titles'],
           },
+          _splitIntoSections: splitSearchHeadings,
         },
+        _render: renderSearchHeadings,
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ the backup through GitHub's official Pages actions. The repository Pages source
 must therefore be set to **GitHub Actions**; this workflow does not publish a
 `gh-pages` branch. Domain ownership and routing are managed in the hosting and
 DNS control planes, so do not add a checked-in `CNAME` file. The checked-in
-`vercel.json` runs the complete validation suite before every Vercel build.
+GitHub workflows run the complete validation suite and verify that the
+canonical Vercel site serves the exact `main` revision, renders the language
+selector, and exposes a translated locale before reporting success. Vercel's
+project settings own its build and output configuration.
 
 ## Validation
 
@@ -47,6 +50,7 @@ pnpm test
 pnpm validate
 pnpm build
 pnpm cli validate-links .vitepress/dist
+pnpm cli validate-locales .vitepress/dist
 ```
 
 `pnpm validate:i18n` requires every English route in all 20 maintained

--- a/etc/cli.ts
+++ b/etc/cli.ts
@@ -1,6 +1,7 @@
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { scanAndReport } from './validate-links'
+import { scanBuiltLocalesAndReport } from './validate-locales-build'
 
 yargs(hideBin(process.argv))
   .command(
@@ -14,6 +15,22 @@ yargs(hideBin(process.argv))
       await scanAndReport({
         root: opts.root,
         publicPath: opts.publicPath ?? undefined,
+      })
+    },
+  )
+  .command(
+    'validate-locales <root>',
+    'Verifies built locale roots and the language selector',
+    (y) =>
+      y
+        .positional('root', { description: "Root directory of VitePress's output", type: 'string', demandOption: true })
+        .option('public-path', { description: 'Public path used in locale links', default: '/', type: 'string' })
+        .option('revision', { description: 'Expected deployment revision', default: null, type: 'string' }),
+    async (opts) => {
+      await scanBuiltLocalesAndReport({
+        root: opts.root,
+        publicPath: opts.publicPath,
+        revision: opts.revision ?? process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA,
       })
     },
   )

--- a/etc/search-index.spec.ts
+++ b/etc/search-index.spec.ts
@@ -1,0 +1,51 @@
+import MarkdownIt from 'markdown-it'
+import { describe, expect, test } from 'vitest'
+import { renderSearchHeadings, splitSearchHeadings } from './search-index'
+
+function markdownWithAnchors(): MarkdownIt {
+  const markdown = new MarkdownIt()
+  markdown.core.ruler.push('test-heading-anchors', (state) => {
+    for (let index = 0; index < state.tokens.length; index += 1) {
+      const token = state.tokens[index]
+      if (token.type !== 'heading_open') continue
+      const inline = state.tokens[index + 1]
+      const title = inline.children?.map((child) => child.content).join('') ?? ''
+      token.attrSet('id', title.toLowerCase().replaceAll(' ', '-'))
+    }
+  })
+  return markdown
+}
+
+describe('search index rendering', () => {
+  test('extracts heading hierarchy and anchors without rendered page bodies', () => {
+    const rendered = renderSearchHeadings(
+      '# Iroha\n\nBody that is not indexed.\n\n## Install `irohad`\n\nMore body.',
+      {},
+      markdownWithAnchors(),
+    )
+
+    expect(splitSearchHeadings('guide.md', rendered)).toEqual([
+      { anchor: 'iroha', text: 'Iroha', titles: ['Iroha'] },
+      { anchor: 'install-irohad', text: 'Install irohad', titles: ['Iroha', 'Install irohad'] },
+    ])
+    expect(rendered).not.toContain('Body that is not indexed')
+  })
+
+  test('does not parse headings or retain content inside code fences', () => {
+    const rendered = renderSearchHeadings(
+      '# Visible\n\n```markdown\n## Hidden\nlarge duplicated code sample\n```',
+      {},
+      markdownWithAnchors(),
+    )
+
+    expect(splitSearchHeadings('guide.md', rendered)).toEqual([
+      { anchor: 'visible', text: 'Visible', titles: ['Visible'] },
+    ])
+    expect(rendered).not.toContain('large duplicated code sample')
+  })
+
+  test('honors pages excluded from search', () => {
+    const rendered = renderSearchHeadings('# Hidden', { frontmatter: { search: false } }, markdownWithAnchors())
+    expect(splitSearchHeadings('hidden.md', rendered)).toEqual([])
+  })
+})

--- a/etc/search-index.ts
+++ b/etc/search-index.ts
@@ -1,0 +1,66 @@
+import type MarkdownIt from 'markdown-it'
+
+export interface SearchHeading {
+  anchor: string
+  text: string
+  titles: string[]
+}
+
+interface SearchMarkdownEnvironment {
+  frontmatter?: {
+    search?: boolean
+  }
+}
+
+function inlineTitle(token: ReturnType<MarkdownIt['parse']>[number] | undefined): string {
+  return (
+    token?.children
+      ?.filter((child) => child.type === 'text' || child.type === 'code_inline')
+      .map((child) => child.content)
+      .join('')
+      .trim() ?? ''
+  )
+}
+
+export function renderSearchHeadings(
+  source: string,
+  environment: SearchMarkdownEnvironment,
+  markdown: MarkdownIt,
+): string {
+  if (environment.frontmatter?.search === false) return '[]'
+
+  const tokens = markdown.parse(source, environment)
+  const parentTitles: string[] = []
+  const sections: SearchHeading[] = []
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (token.type !== 'heading_open') continue
+
+    const level = Number.parseInt(token.tag.slice(1), 10) - 1
+    const title = inlineTitle(tokens[index + 1])
+    if (level < 0 || !title) continue
+
+    const titles = parentTitles.slice(0, level)
+    titles[level] = title
+    const compactTitles = titles.filter(Boolean)
+
+    sections.push({
+      anchor: token.attrGet('id') ?? '',
+      text: title,
+      titles: compactTitles,
+    })
+
+    if (level === 0) {
+      parentTitles.splice(0, parentTitles.length, title)
+    } else {
+      parentTitles[level] = title
+    }
+  }
+
+  return JSON.stringify(sections)
+}
+
+export function splitSearchHeadings(_path: string, rendered: string): SearchHeading[] {
+  return JSON.parse(rendered) as SearchHeading[]
+}

--- a/etc/validate-locales-build.spec.ts
+++ b/etc/validate-locales-build.spec.ts
@@ -1,0 +1,169 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { describe, expect, test } from 'vitest'
+import { ALL_LOCALES, ROOT_LOCALE, type DocsLocale } from './locales'
+import { scanBuiltLocales } from './validate-locales-build'
+
+function localeHref(locale: DocsLocale, publicPath: string): string {
+  return `${publicPath}${locale.path ? `${locale.path}/` : ''}`
+}
+
+function rootHtml(
+  publicPath: string,
+  options: { omittedLocale?: DocsLocale; revision?: string; wrongLabelLocale?: DocsLocale } = {},
+): string {
+  const links = ALL_LOCALES.filter((locale) => locale !== ROOT_LOCALE)
+    .filter((locale) => locale !== options.omittedLocale)
+    .map(
+      (locale) =>
+        `<a href="${localeHref(locale, publicPath)}">${locale === options.wrongLabelLocale ? '' : locale.label}</a>`,
+    )
+    .join('')
+
+  const revision = options.revision
+    ? `<head><meta name="iroha-docs-revision" content="${options.revision}"></head>`
+    : ''
+  return `<html lang="en" dir="ltr">${revision}<body><div class="VPNavBarTranslations"><button aria-label="Change language"></button>${links}</div></body></html>`
+}
+
+async function writeLocaleFixture(
+  root: string,
+  publicPath: string,
+  options: { omittedLocale?: DocsLocale; revision?: string; wrongLabelLocale?: DocsLocale } = {},
+): Promise<void> {
+  await Promise.all(
+    ALL_LOCALES.map(async (locale) => {
+      const directory = path.join(root, locale.path)
+      await mkdir(directory, { recursive: true })
+      const html =
+        locale === ROOT_LOCALE
+          ? rootHtml(publicPath, options)
+          : `<html lang="${locale.lang}" dir="${locale.direction}"><body></body></html>`
+      await writeFile(path.join(directory, 'index.html'), html)
+    }),
+  )
+}
+
+async function withFixture(
+  publicPath: string,
+  callback: (root: string) => Promise<void>,
+  options: { omittedLocale?: DocsLocale; revision?: string; wrongLabelLocale?: DocsLocale } = {},
+): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), 'iroha-docs-built-locales-'))
+  try {
+    await writeLocaleFixture(root, publicPath, options)
+    await callback(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+describe('built locale validation', () => {
+  test.each([
+    { option: undefined, builtPath: '/' },
+    { option: '/iroha-docs/', builtPath: '/iroha-docs/' },
+    { option: '/iroha-docs', builtPath: '/iroha-docs/' },
+    { option: 'iroha-docs', builtPath: '/iroha-docs/' },
+  ])('accepts a complete language selector for public path $option', async ({ option, builtPath }) => {
+    await withFixture(builtPath, async (root) => {
+      expect(await scanBuiltLocales({ root, publicPath: option })).toEqual([])
+    })
+  })
+
+  test('reports a missing language selector', async () => {
+    await withFixture('/', async (root) => {
+      await writeFile(path.join(root, 'index.html'), '<html lang="en" dir="ltr"><body></body></html>')
+      expect(await scanBuiltLocales({ root })).toContain('English locale index does not render the language selector')
+    })
+  })
+
+  test('accepts the expected deployment revision', async () => {
+    await withFixture(
+      '/',
+      async (root) => {
+        expect(await scanBuiltLocales({ root, revision: 'abc123' })).toEqual([])
+      },
+      { revision: 'abc123' },
+    )
+  })
+
+  test('reports a stale deployment revision', async () => {
+    await withFixture(
+      '/',
+      async (root) => {
+        expect(await scanBuiltLocales({ root, revision: 'new-sha' })).toContain(
+          'built revision is old-sha; expected new-sha',
+        )
+      },
+      { revision: 'old-sha' },
+    )
+  })
+
+  test('reports a missing locale link', async () => {
+    const japanese = ALL_LOCALES.find((locale) => locale.key === 'ja')!
+    await withFixture(
+      '/',
+      async (root) => {
+        expect(await scanBuiltLocales({ root })).toContain('language selector is missing 日本語: /ja/')
+      },
+      { omittedLocale: japanese },
+    )
+  })
+
+  test('reports an empty language label', async () => {
+    const french = ALL_LOCALES.find((locale) => locale.key === 'fr')!
+    await withFixture(
+      '/',
+      async (root) => {
+        expect(await scanBuiltLocales({ root })).toContain(
+          'language selector link /fr/ is labelled (empty); expected Français',
+        )
+      },
+      { wrongLabelLocale: french },
+    )
+  })
+
+  test('reports a missing accessible button label', async () => {
+    await withFixture('/', async (root) => {
+      const html = rootHtml('/').replace(' aria-label="Change language"', '')
+      await writeFile(path.join(root, 'index.html'), html)
+      expect(await scanBuiltLocales({ root })).toContain(
+        'language selector is missing a non-empty accessible button label',
+      )
+    })
+  })
+
+  test('reports a missing locale root once', async () => {
+    const japanese = ALL_LOCALES.find((locale) => locale.key === 'ja')!
+    await withFixture('/', async (root) => {
+      await rm(path.join(root, japanese.path, 'index.html'))
+      const issues = await scanBuiltLocales({ root })
+      expect(issues.filter((issue) => issue.includes('missing 日本語 locale index'))).toHaveLength(1)
+    })
+  })
+
+  test('reports incorrect language metadata', async () => {
+    const japanese = ALL_LOCALES.find((locale) => locale.key === 'ja')!
+    await withFixture('/', async (root) => {
+      await writeFile(path.join(root, japanese.path, 'index.html'), '<html lang="en" dir="ltr"></html>')
+      expect(await scanBuiltLocales({ root })).toContain('日本語 locale index has lang=en; expected ja')
+    })
+  })
+
+  test('reports a missing html element', async () => {
+    const japanese = ALL_LOCALES.find((locale) => locale.key === 'ja')!
+    await withFixture('/', async (root) => {
+      await writeFile(path.join(root, japanese.path, 'index.html'), '<p>broken</p>')
+      expect(await scanBuiltLocales({ root })).toContain('日本語 locale index has no html element')
+    })
+  })
+
+  test('reports incorrect right-to-left metadata', async () => {
+    const arabic = ALL_LOCALES.find((locale) => locale.key === 'ar')!
+    await withFixture('/', async (root) => {
+      await writeFile(path.join(root, arabic.path, 'index.html'), '<html lang="ar" dir="ltr"></html>')
+      expect(await scanBuiltLocales({ root })).toContain('العربية locale index has dir=ltr; expected rtl')
+    })
+  })
+})

--- a/etc/validate-locales-build.ts
+++ b/etc/validate-locales-build.ts
@@ -1,0 +1,121 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+import chalk from 'chalk'
+import * as cssSelect from 'css-select'
+import * as htmlparser from 'htmlparser2'
+import { ALL_LOCALES, ROOT_LOCALE } from './locales'
+
+interface Options {
+  root: string
+  publicPath?: string
+  revision?: string
+}
+
+function normalizePublicPath(publicPath = '/'): string {
+  const withLeadingSlash = publicPath.startsWith('/') ? publicPath : `/${publicPath}`
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`
+}
+
+function localeIndex(root: string, localePath: string): string {
+  return path.join(root, localePath, 'index.html')
+}
+
+function localeHref(localePath: string, publicPath: string): string {
+  return `${publicPath}${localePath ? `${localePath}/` : ''}`
+}
+
+export async function scanBuiltLocales(options: Options): Promise<string[]> {
+  const issues: string[] = []
+  const publicPath = normalizePublicPath(options.publicPath)
+  const htmlByLocale = new Map<string, string>()
+
+  await Promise.all(
+    ALL_LOCALES.map(async (locale) => {
+      const indexFile = localeIndex(options.root, locale.path)
+      try {
+        htmlByLocale.set(locale.key, await readFile(indexFile, 'utf8'))
+      } catch {
+        issues.push(`missing ${locale.label} locale index: ${indexFile}`)
+      }
+    }),
+  )
+
+  const rootHtml = htmlByLocale.get(ROOT_LOCALE.key)
+
+  if (rootHtml) {
+    const document = htmlparser.parseDocument(rootHtml)
+    if (options.revision) {
+      const revisionMeta = cssSelect.selectOne('meta[name="iroha-docs-revision"]', document.children)
+      const builtRevision = revisionMeta && 'attribs' in revisionMeta ? revisionMeta.attribs.content?.trim() : undefined
+      if (builtRevision !== options.revision) {
+        issues.push(`built revision is ${builtRevision ?? '(missing)'}; expected ${options.revision}`)
+      }
+    }
+
+    const translationMenu = cssSelect.selectOne('.VPNavBarTranslations', document.children)
+
+    if (!translationMenu) {
+      issues.push('English locale index does not render the language selector')
+    } else {
+      const button = cssSelect.selectOne('button', [translationMenu])
+      const buttonLabel = button && 'attribs' in button ? button.attribs['aria-label']?.trim() : undefined
+      if (!buttonLabel) issues.push('language selector is missing a non-empty accessible button label')
+
+      const links = new Map(
+        cssSelect.selectAll('a[href]', [translationMenu]).flatMap((element) => {
+          if (!('attribs' in element) || !element.attribs.href) return []
+          return [[element.attribs.href, htmlparser.DomUtils.textContent(element).trim()] as const]
+        }),
+      )
+
+      for (const locale of ALL_LOCALES) {
+        if (locale === ROOT_LOCALE) continue
+        const expectedHref = localeHref(locale.path, publicPath)
+        const label = links.get(expectedHref)
+        if (label === undefined) {
+          issues.push(`language selector is missing ${locale.label}: ${expectedHref}`)
+        } else if (label !== locale.label) {
+          issues.push(
+            `language selector link ${expectedHref} is labelled ${label || '(empty)'}; expected ${locale.label}`,
+          )
+        }
+      }
+    }
+  }
+
+  for (const locale of ALL_LOCALES) {
+    const html = htmlByLocale.get(locale.key)
+    if (html) {
+      const document = htmlparser.parseDocument(html)
+      const htmlElement = cssSelect.selectOne('html', document.children)
+      if (!htmlElement || !('attribs' in htmlElement)) {
+        issues.push(`${locale.label} locale index has no html element`)
+        continue
+      }
+
+      if (htmlElement.attribs.lang !== locale.lang) {
+        issues.push(
+          `${locale.label} locale index has lang=${htmlElement.attribs.lang ?? '(missing)'}; expected ${locale.lang}`,
+        )
+      }
+      if (htmlElement.attribs.dir !== locale.direction) {
+        issues.push(
+          `${locale.label} locale index has dir=${htmlElement.attribs.dir ?? '(missing)'}; expected ${locale.direction}`,
+        )
+      }
+    }
+  }
+
+  return issues.sort()
+}
+
+export async function scanBuiltLocalesAndReport(options: Options): Promise<void> {
+  const issues = await scanBuiltLocales(options)
+  if (issues.length === 0) {
+    console.log(chalk.green(`✓ Language selector and ${ALL_LOCALES.length} locale roots are present`))
+    return
+  }
+
+  console.error(issues.map((issue) => chalk.red(`× ${issue}`)).join('\n'))
+  process.exitCode = 1
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "dev": "vitepress dev",
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 vitepress build",
+    "build": "NODE_OPTIONS=--max-old-space-size=6144 vitepress build",
     "serve": "vitepress serve",
     "format": "prettier-eslint --include-dot-files \"**/*.{js,ts,mts,vue,json}\"",
     "format:check": "pnpm format --list-different",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm validate && pnpm build",
-  "outputDirectory": ".vitepress/dist"
-}


### PR DESCRIPTION
## Summary

- keep `docs.iroha.tech` on Vercel and retain GitHub Pages at `/iroha-docs/` as the backup
- remove the new repository-level Vercel override so the established Vercel project settings own the build again
- extract VitePress site metadata into one shared chunk, reducing the 20-locale output from 680.4 MiB to 187.1 MiB
- index headings directly for the existing title-only local search instead of rendering and highlighting all 1,975 pages a second time
- bound the VitePress heap and page-render concurrency for Vercel’s build container
- stamp Vercel builds with their Git commit and verify the live revision, language selector, locale roots, language metadata, and RTL direction

## Root cause

PR #531 introduced two independent deployment problems. Its new `vercel.json` override made deployments fail in roughly 20–40 seconds, before VitePress rendering; removing it lets the established Vercel project build run normally. Once the real build ran, VitePress exhausted the 8 GiB build container and produced 680.4 MiB because every HTML file embedded the same roughly 262 KiB metadata payload. Local search also fully rendered every translated page even though its configured fields are only titles.

The optimized build completes in 96 seconds with a 6 GiB Node heap, emits one shared metadata chunk, preserves all translated routes and title search indexes, and produces 187.1 MiB.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (161 tests)
- `pnpm validate` (20 translated locales and provenance)
- `pnpm build` with Node 24 and pnpm 9.12.1 (96 seconds)
- `pnpm cli validate-links .vitepress/dist`
- `pnpm cli validate-locales .vitepress/dist --revision <commit>`
- confirmed 21 generated local-search index chunks
- measured output: 187.1 MiB, down from 680.4 MiB

No DNS change is required. The separate `iroha.tech` landing page is unaffected.